### PR TITLE
Upgrade earmark and ex_doc to clear elixir warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,8 +40,8 @@ defmodule Slugger.Mixfile do
 
   defp deps() do
     [
-      {:earmark, "~> 0.1.17", only: :dev},
-      {:ex_doc, "~> 0.6", only: :dev},
+      {:earmark, "~> 1.2.2", only: :dev},
+      {:ex_doc, "~> 0.16.1", only: :dev},
       {:benchfella, "~> 0.3.0", only: :dev},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:poison, "~> 3.0", only: [:dev, :test]},


### PR DESCRIPTION

The current version of earmark (and a dependency on ex_doc) are generating the following warnings for me on Elixir 1.4.2


Here are the current warnings in slugger

```
09:53 ~/sin/projects/oss/slugger (master)$ mix compile
==> poison
Compiling 4 files (.ex)
Generated poison app
==> benchfella
Compiling 9 files (.ex)
Generated benchfella app
==> dialyxir
Compiling 5 files (.ex)
Generated dialyxir app
warning: variable "escript_config" does not exist and is being expanded to "escript_config()", please use parentheses to remove the ambiguity or change the variable name
  /Users/aforward/sin/projects/oss/slugger/deps/earmark/mix.exs:11

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /Users/aforward/sin/projects/oss/slugger/deps/earmark/mix.exs:12

warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  /Users/aforward/sin/projects/oss/slugger/deps/earmark/mix.exs:13

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /Users/aforward/sin/projects/oss/slugger/deps/earmark/mix.exs:14

==> earmark
Compiling 9 files (.ex)
warning: HashDict.new/0 is deprecated, use maps and the Map module instead
  lib/earmark/context.ex:24

warning: HashDict.new/0 is deprecated, use maps and the Map module instead
  lib/earmark/context.ex:26

warning: the variable "line" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/earmark/helpers.ex:10

warning: the variable "blocks" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/earmark.ex:177

warning: the variable "context" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/earmark.ex:177

warning: parentheses are required when piping into a function call. For example:

    foo 1 |> bar 2 |> baz 3

is ambiguous and should be written as

    foo(1) |> bar(2) |> baz(3)

Ambiguous pipe found at:
  lib/earmark/inline.ex:307

warning: HashDict.new/0 is deprecated, use maps and the Map module instead
  lib/earmark/parser.ex:28

warning: Dict.fetch/2 is deprecated, use the Map module for working with maps or the Keyword module for working with keyword lists
  lib/earmark/inline.ex:207

warning: Dict.fetch/2 is deprecated, use the Map module for working with maps or the Keyword module for working with keyword lists
  lib/earmark/inline.ex:214

warning: variable "basic_rules" does not exist and is being expanded to "basic_rules()", please use parentheses to remove the ambiguity or change the variable name
  lib/earmark/inline.ex:306

warning: the variable "rule_updates" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/earmark/inline.ex:304

warning: the variable "rule_updates" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/earmark/inline.ex:302

warning: the variable "rule_updates" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/earmark/inline.ex:306

warning: the variable "html" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/earmark/html_renderer.ex:85

warning: HashDict.new/0 is deprecated, use maps and the Map module instead
  lib/earmark/html_renderer.ex:193

warning: Dict.update/4 is deprecated, use the Map module for working with maps or the Keyword module for working with keyword lists
  lib/earmark/html_renderer.ex:205

warning: Dict.update/4 is deprecated, use the Map module for working with maps or the Keyword module for working with keyword lists
  lib/earmark/html_renderer.ex:210

warning: Dict.update/4 is deprecated, use the Map module for working with maps or the Keyword module for working with keyword lists
  lib/earmark/html_renderer.ex:215

warning: Dict.update/4 is deprecated, use the Map module for working with maps or the Keyword module for working with keyword lists
  lib/earmark/html_renderer.ex:220

warning: Dict.update/4 is deprecated, use the Map module for working with maps or the Keyword module for working with keyword lists
  lib/earmark/html_renderer.ex:225

warning: the variable "rest" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/earmark/block.ex:175

warning: the variable "html_lines" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/earmark/block.ex:211

warning: the variable "rest" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/earmark/block.ex:212

warning: HashDict.new/0 is deprecated, use maps and the Map module instead
  lib/earmark/block.ex:438

warning: Dict.put/3 is deprecated, use the Map module for working with maps or the Keyword module for working with keyword lists
  lib/earmark/block.ex:442

Generated earmark app
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /Users/aforward/sin/projects/oss/slugger/deps/ex_doc/mix.exs:9

warning: variable "aliases" does not exist and is being expanded to "aliases()", please use parentheses to remove the ambiguity or change the variable name
  /Users/aforward/sin/projects/oss/slugger/deps/ex_doc/mix.exs:10

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /Users/aforward/sin/projects/oss/slugger/deps/ex_doc/mix.exs:11

==> ex_doc
Compiling 12 files (.ex)
warning: variable "do_version" does not exist and is being expanded to "do_version()", please use parentheses to remove the ambiguity or change the variable name
  lib/ex_doc/cli.ex:19

warning: variable "assets" does not exist and is being expanded to "assets()", please use parentheses to remove the ambiguity or change the variable name
  lib/ex_doc/formatter/html.ex:21

warning: variable "find_markdown_processor" does not exist and is being expanded to "find_markdown_processor()", please use parentheses to remove the ambiguity or change the variable name
  lib/ex_doc/markdown.ex:58

warning: variable "raise_no_markdown_processor" does not exist and is being expanded to "raise_no_markdown_processor()", please use parentheses to remove the ambiguity or change the variable name
  lib/ex_doc/markdown.ex:58

warning: crypto:rand_bytes/1 is deprecated and will be removed in a future release; use crypto:strong_rand_bytes/1
  lib/ex_doc/markdown/pandoc.ex:31

warning: function Cmark.to_html/1 is undefined (module Cmark is not available)
  lib/ex_doc/markdown/cmark.ex:18

warning: function Markdown.to_html/2 is undefined (module Markdown is not available)
  lib/ex_doc/markdown/hoedown.ex:29

Generated ex_doc app
==> slugger
Compiling 2 files (.ex)
Generated slugger app
09:54 ~/sin/projects/oss/slugger (master)$ 
```

After upgrading,

```
10:04 ~/sin/projects/oss/slugger (f/upgrade-earmark)$ mix deps.compile --force
==> poison
Compiling 4 files (.ex)
Generated poison app
==> benchfella
Compiling 9 files (.ex)
Generated benchfella app
==> dialyxir
Compiling 5 files (.ex)
Generated dialyxir app
==> earmark
Compiling 3 files (.erl)
Compiling 25 files (.ex)
warning: implementation not provided for predefined defp hard_line_breaks/2
  lib/earmark/inline.ex:248

Generated earmark app
==> ex_doc
Compiling 15 files (.ex)
Generated ex_doc app
10:04 ~/sin/projects/oss/slugger (f/upgrade-earmark)$ mix compile --force
Compiling 2 files (.ex)
Generated slugger app
10:04 ~/sin/projects/oss/slugger (f/upgrade-earmark)$ mix test
.......................

Finished in 0.1 seconds
23 tests, 0 failures

Randomized with seed 209307
```

That last warning seems fixed in master of earmark, but I thought it best to wait for an official new release.
