### PR TITLE
Add Korean language support

### DIFF
--- a/lib/slugger.ex
+++ b/lib/slugger.ex
@@ -38,7 +38,7 @@ defmodule Slugger do
   def slugify(text, separator \\ @separator_char) do
     text
     |> replace_special_chars
-    |> remove_unwanted_chars(separator, ~r/([^A-Za-z0-9])+/)
+    |> remove_unwanted_chars(separator, ~r/([^A-Za-z0-9가-힣])+/)
   end
   
   @doc """
@@ -64,7 +64,7 @@ defmodule Slugger do
     text
     |> replace_special_chars
     |> String.downcase
-    |> remove_unwanted_chars(separator, ~r/([^a-z0-9])+/)
+    |> remove_unwanted_chars(separator, ~r/([^a-z0-9가-힣])+/)
   end
   
   @spec remove_unwanted_chars(text :: String.t, separator :: char, pattern :: Regex.t) :: String.t


### PR DESCRIPTION
While making blog platform with this library,
I thought it might be helpful for someone (like me) to support Korean language also.

I added [가-힣] to each regular expressions.
It will cover all korean characters.

thank you.