### PR TITLE
Fix Unicode regular expressions

### DIFF
--- a/lib/slugger.ex
+++ b/lib/slugger.ex
@@ -39,7 +39,7 @@ defmodule Slugger do
     text
     |> handle_possessives
     |> replace_special_chars
-    |> remove_unwanted_chars(separator, ~r/([^A-Za-z0-9가-힣])+/)
+    |> remove_unwanted_chars(separator, ~r/([^A-Za-z0-9가-힣])+/u)
   end
 
   @doc """
@@ -66,7 +66,7 @@ defmodule Slugger do
     |> handle_possessives
     |> replace_special_chars
     |> String.downcase
-    |> remove_unwanted_chars(separator, ~r/([^a-z0-9가-힣])+/)
+    |> remove_unwanted_chars(separator, ~r/([^a-z0-9가-힣])+/u)
   end
 
   @spec remove_unwanted_chars(text :: String.t, separator :: char, pattern :: Regex.t) :: String.t

--- a/test/slugger_test.exs
+++ b/test/slugger_test.exs
@@ -21,7 +21,7 @@ defmodule SluggerTest do
   end
 
   test "removing space at ending and ending with korean chars" do
-    assert Slugger.slugify(" \n  \t \n ㅈㅓㅇㅅㅜㅇㅕㄴ for 정수연 \n  \t \n ") == "ㅈㅓㅇㅅㅜㅇㅕㄴ-for-정수연"
+    assert Slugger.slugify(" \n  \t \n 정수연 for 정수연 \n  \t \n ") == "정수연-for-정수연"
   end
 
   test "replace whitespace inside with seperator" do

--- a/test/slugger_test.exs
+++ b/test/slugger_test.exs
@@ -28,7 +28,7 @@ defmodule SluggerTest do
     assert Slugger.slugify("   A B  C  ") == "A-B-C"
     assert Slugger.slugify("   A B  C  ", ?_) == "A_B_C"
   end
-  
+
   test "replace multiple seperator inside and outside" do
     assert Slugger.slugify("--a--b c - - - ") == "a-b-c"
   end
@@ -44,8 +44,12 @@ defmodule SluggerTest do
     assert Slugger.slugify("Sheep's Milk") == "Sheeps-Milk"
   end
 
+  test "removing unwanted unicode characters" do
+    assert Slugger.slugify("abc 😀") == "abc"
+  end
+
   #--- slugify_downcase()
-  
+
   test "string to lower" do
     assert Slugger.slugify_downcase("ABC") == "abc"
   end
@@ -69,6 +73,10 @@ defmodule SluggerTest do
 
   test "removing space between possessives lowercase" do
     assert Slugger.slugify_downcase("Sheep's Milk") == "sheeps-milk"
+  end
+
+  test "removing unwanted unicode characters lowercase" do
+    assert Slugger.slugify_downcase("abc 😀") == "abc"
   end
 
   #--- Naughty strings


### PR DESCRIPTION
Slugifying strings containing Unicode characters can lead to invalid results:

```ex
iex(1)> Slugger.slugify("abc 😀")
<<97, 98, 99, 45, 159, 152, 128>>
```

Regular expressions do not match Unicode by default. Adding the `unicode` modifier seems to resolve the issue.